### PR TITLE
AMRNAV-4605 Filter out the floor

### DIFF
--- a/pcl_filter/params.yaml
+++ b/pcl_filter/params.yaml
@@ -2,4 +2,3 @@
   plane_clipper:
     ros__parameters:
       planes: [1.0, 0.0, 0.0, -1.62, -0.015, 0.0, 1.015, -0.04] # Last plane is rotated to filter out the floor. https://lvserv01.logivations.com/browse/AMRNAV-4605
-      set_plane_negative: [False, False]

--- a/pcl_filter/params.yaml
+++ b/pcl_filter/params.yaml
@@ -1,0 +1,5 @@
+/**:
+  plane_clipper:
+    ros__parameters:
+      planes: [1.0, 0.0, 0.0, -1.62, -0.015, 0.0, 1.015, -0.04] # Last plane is rotated to filter out the floor. https://lvserv01.logivations.com/browse/AMRNAV-4605
+      set_plane_negative: [False, False]


### PR DESCRIPTION
AMR4 probably needs kinect calibration. In rosbags we see the floor on the pointcloud.
I modified the plane to have some angle (around 3 degrees with xy plane) as a hotfix 

Rosbags from AMR4: https://drive.google.com/file/d/1pOIz7uOI7JiD832JM2ZytZzsmoTJo1kn/view?usp=sharing


See the video for before and after the changes. ( pointcloud from one of the rosbags was copied to gazebo ) 
[Screencast from 23.04.23 21:35:10.webm](https://user-images.githubusercontent.com/87417416/233870492-244ccc3b-820b-497c-bc13-063a1235be9f.webm)
